### PR TITLE
fix(build): es6 module babel transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
-  "module": "src/index.js",
+  "module": "dist/index.module.js",
   "scripts": {
     "lint": "eslint .",
     "test": "jest",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,11 +3,17 @@ import pkg from './package.json';
 
 export default {
     input: 'src/index.js',
-    output: {
+    output: [
+      {
         file: pkg.main,
         name: 'blockUtils',
         format: 'umd'
-    },
+      },
+      {
+        file: pkg.module,
+        format: 'esm'
+      }
+    ],
     plugins: [
         babel({
             exclude: ['node_modules/**']


### PR DESCRIPTION
Updates build tasks and package.json sure that the "module" field points
to a correctly trasnpiled es6 module, rather than the untranspiled
source files.

This update should fix the build errors we're currently experiencing when trying to use this package in `zero-Blocks`.